### PR TITLE
Fix hero video and image source paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,8 @@
     <section class="hero">
         <div class="hero-image">
             <video class="hero-video" autoplay muted loop playsinline>
-                <source src="/images/video/intro.mp4" type="video/mp4">
-                <img src="/placeholder.svg?height=400&width=300" alt="Latest iPhone">
+                <source src="images/video/intro.mp4" type="video/mp4">
+                <img src="placeholder.svg?height=400&width=300" alt="Latest iPhone">
             </video>
     
             <div class="hero-overlay">


### PR DESCRIPTION
Removed leading slashes from the video and image source paths in the hero section to ensure correct relative path resolution.